### PR TITLE
Raise response error instead of a string

### DIFF
--- a/agendor-ruby.gemspec
+++ b/agendor-ruby.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "agendor-ruby"
-  s.version = "2.4.2"
+  s.version = "2.4.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/agendor-ruby.gemspec
+++ b/agendor-ruby.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "agendor-ruby"
-  s.version = "2.4.3"
+  s.version = "2.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/lib/agendor/base.rb
+++ b/lib/agendor/base.rb
@@ -30,19 +30,11 @@ module Agendor
     end
   end
 
-  class EntityProcessingError < StandardError
-      attr_reader :response
+  class UnauthorizedError < StandardError
+    attr_reader :response
 
-      def initialize(message = 'Error processing Agendor entity', response)
-        @response = response
-      end
+    def initialize(message = 'Unauthorized request', response)
+      @response = response
     end
-
-    class UnauthorizedError < StandardError
-      attr_reader :response
-
-      def initialize(message = 'Unauthorized request', response)
-        @response = response
-      end
-    end
+  end
 end

--- a/lib/agendor/base.rb
+++ b/lib/agendor/base.rb
@@ -28,6 +28,21 @@ module Agendor
     def api_path
       "https://api.agendor.com.br/v1"
     end
-
   end
+
+  class EntityProcessingError < StandardError
+      attr_reader :response
+
+      def initialize(message = 'Error processing Agendor entity', response)
+        @response = response
+      end
+    end
+
+    class UnauthorizedError < StandardError
+      attr_reader :response
+
+      def initialize(message = 'Unauthorized request', response)
+        @response = response
+      end
+    end
 end

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -7,19 +7,18 @@ module Agendor
     def create(params)
       body = process_hash(params)
       response = HTTParty.post(resource_path, body: body.to_json, headers: headers)
-      raise EntityProcessingError, response unless response =~ SUCCESS_RESPONSE_CODE
+      raise EntityProcessingError.new(response) unless response =~ SUCCESS_RESPONSE_CODE
     end
 
     def get(query)
-      binding.pry
       response = HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
-      raise EntityProcessingError, response unless response =~ SUCCESS_RESPONSE_CODE
+      raise EntityProcessingError.new(response) unless response =~ SUCCESS_RESPONSE_CODE
     end
 
     def update(entity_id, params)
       body = process_hash(params)
       response = HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
-      raise EntityProcessingError, response unless response =~ SUCCESS_RESPONSE_CODE
+      raise EntityProcessingError.new(response) unless response =~ SUCCESS_RESPONSE_CODE
     end
 
     def process_hash(params)
@@ -28,7 +27,9 @@ module Agendor
 
     # This response should be raised when an error occurs
     class EntityProcessingError < StandardError
-      def initialize(response)
+      attr_reader :response
+
+      def initialize(_message = 'Error processing Agendor entity', response)
         @response = response
       end
     end

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -6,7 +6,7 @@ module Agendor
       response = HTTParty.post(resource_path, body: body.to_json, headers: headers)
       code = response.code
       raise UnauthorizedError.new(response) if code == 401
-      raise EntityProcessingError.new(response) unless success_response?(code)
+      raise ProcessingError.new(response) unless success_response?(code)
       klass_object_id(response.parsed_response)
     end
 
@@ -14,7 +14,7 @@ module Agendor
       response = HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
       code = response.code
       raise UnauthorizedError.new(response) if code == 401
-      raise EntityProcessingError.new(response) unless success_response?(code)
+      raise ProcessingError.new(response) unless success_response?(code)
       response.parsed_response
     end
 
@@ -23,7 +23,7 @@ module Agendor
       response = HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
       code = response.code
       raise UnauthorizedError.new(response) if code == 401
-      raise EntityProcessingError.new(response) unless success_response?(code)
+      raise ProcessingError.new(response) unless success_response?(code)
       klass_object_id(response.parsed_response)
     end
 
@@ -35,6 +35,14 @@ module Agendor
 
     def success_response?(code)
       code.between?(200, 299)
+    end
+
+    class ProcessingError < StandardError
+      attr_reader :response
+
+      def initialize(message = 'Error processing Agendor entity', response)
+        @response = response
+      end
     end
   end
 end

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -12,6 +12,7 @@ module Agendor
 
     def get(query)
       response = HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
+      code = response.code
       raise UnauthorizedError.new(response) if code == 401
       raise EntityProcessingError.new(response) unless success_response?(code)
       response.parsed_response
@@ -20,6 +21,7 @@ module Agendor
     def update(entity_id, params)
       body = process_hash(params)
       response = HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
+      code = response.code
       raise UnauthorizedError.new(response) if code == 401
       raise EntityProcessingError.new(response) unless success_response?(code)
       klass_object_id(response.parsed_response)

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -34,21 +34,5 @@ module Agendor
     def success_response?(code)
       code.between?(200, 299)
     end
-
-    class EntityProcessingError < StandardError
-      attr_reader :response
-
-      def initialize(message = 'Error processing Agendor entity', response)
-        @response = response
-      end
-    end
-
-    class UnauthorizedError < StandardError
-      attr_reader :response
-
-      def initialize(message = 'Unauthorized request', response)
-        @response = response
-      end
-    end
   end
 end

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -2,23 +2,34 @@ module Agendor
 
   class Entity < Agendor::Base
 
+    SUCCESS_RESPONSE_CODE = /2\d\d/
+
     def create(params)
       body = process_hash(params)
-      HTTParty.post(resource_path, body: body.to_json, headers: headers)
+      response = HTTParty.post(resource_path, body: body.to_json, headers: headers)
+      raise EntityProcessingError, response unless response =~ SUCCESS_RESPONSE_CODE
     end
 
     def get(query)
       HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
+      raise EntityProcessingError, response unless response =~ SUCCESS_RESPONSE_CODE
     end
 
     def update(entity_id, params)
       body = process_hash(params)
       HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
+      raise EntityProcessingError, response unless response =~ SUCCESS_RESPONSE_CODE
     end
 
     def process_hash(params)
       params.select {|k, v| hash_keys.include?(k) }
     end
 
+    # This response should be raised when an error occurs
+    class EntityProcessingError < StandardError
+      def initialize(response)
+        @response = response
+      end
+    end
   end
 end

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -1,24 +1,24 @@
 module Agendor
 
   class Entity < Agendor::Base
-
-    SUCCESS_RESPONSE_CODE = /2\d\d/
-
     def create(params)
       body = process_hash(params)
       response = HTTParty.post(resource_path, body: body.to_json, headers: headers)
       raise EntityProcessingError.new(response) unless success_response?(response.code)
+      klass_object_id(response.parsed_response)
     end
 
     def get(query)
       response = HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
       raise EntityProcessingError.new(response) unless success_response?(response.code)
+      response.parsed_response
     end
 
     def update(entity_id, params)
       body = process_hash(params)
       response = HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
       raise EntityProcessingError.new(response) unless success_response?(response.code)
+      klass_object_id(response.parsed_response)
     end
 
     def process_hash(params)

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -7,22 +7,28 @@ module Agendor
     def create(params)
       body = process_hash(params)
       response = HTTParty.post(resource_path, body: body.to_json, headers: headers)
-      raise EntityProcessingError.new(response) unless response =~ SUCCESS_RESPONSE_CODE
+      raise EntityProcessingError.new(response) unless success_response?(response.code)
     end
 
     def get(query)
       response = HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
-      raise EntityProcessingError.new(response) unless response =~ SUCCESS_RESPONSE_CODE
+      raise EntityProcessingError.new(response) unless success_response?(response.code)
     end
 
     def update(entity_id, params)
       body = process_hash(params)
       response = HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
-      raise EntityProcessingError.new(response) unless response =~ SUCCESS_RESPONSE_CODE
+      raise EntityProcessingError.new(response) unless success_response?(response.code)
     end
 
     def process_hash(params)
       params.select {|k, v| hash_keys.include?(k) }
+    end
+
+    private
+
+    def success_response?(code)
+      code.between?(200, 299)
     end
 
     # This response should be raised when an error occurs

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -4,25 +4,16 @@ module Agendor
 
     def create(params)
       body = process_hash(params)
-      post = HTTParty.post(resource_path, :body => body.to_json, :headers => headers)
-      code = post.response.code
-      raise "Response not HTTP OK: #{code} | #{post.response.body}" if code != "201"
-      klass_object_id(post.parsed_response)
+      HTTParty.post(resource_path, body: body.to_json, headers: headers)
     end
 
     def get(query)
-      get = HTTParty.get("#{resource_path}?q=#{query}", :headers => headers)
-      code = get.response.code
-      raise "Response not HTTP OK: #{code} | #{get.response.body}" if code != "200"
-      get.parsed_response
+      HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
     end
 
     def update(entity_id, params)
       body = process_hash(params)
-      put = HTTParty.put("#{resource_path}/#{entity_id}",:body => body.to_json, :headers => headers)
-      code = put.response.code
-      raise "Response not HTTP OK: #{code} | #{put.response.body}" if code != "200"
-      klass_object_id(put.parsed_response)
+      HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
     end
 
     def process_hash(params)

--- a/lib/agendor/entity.rb
+++ b/lib/agendor/entity.rb
@@ -11,13 +11,14 @@ module Agendor
     end
 
     def get(query)
-      HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
+      binding.pry
+      response = HTTParty.get("#{resource_path}?q=#{query}", headers: headers)
       raise EntityProcessingError, response unless response =~ SUCCESS_RESPONSE_CODE
     end
 
     def update(entity_id, params)
       body = process_hash(params)
-      HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
+      response = HTTParty.put("#{resource_path}/#{entity_id}", body: body.to_json, headers: headers)
       raise EntityProcessingError, response unless response =~ SUCCESS_RESPONSE_CODE
     end
 

--- a/lib/agendor/token.rb
+++ b/lib/agendor/token.rb
@@ -3,10 +3,8 @@ module Agendor
 	class Token < Agendor::Base
 
 		def get_token
-			get = HTTParty.get(resource_path, :headers => headers)
-			code = get.response.code
-			raise "Response not HTTP OK: #{code} | #{get.parsed_response["message"]}" if code != "200"
-			klass_object_id(get.parsed_response)
+			response = HTTParty.get(resource_path, :headers => headers)
+			klass_object_id(response.parsed_response)
 		end
 
 		def resource_path
@@ -16,6 +14,5 @@ module Agendor
 		def klass_object_id(hash)
 			hash["token"]
 		end
-
 	end
 end

--- a/spec/agendor/token_spec.rb
+++ b/spec/agendor/token_spec.rb
@@ -14,8 +14,9 @@ describe Agendor::Token, :vcr do
 
 		let(:client_invalid) { Agendor::Token.new("xunda") }
 
-		it "returns error" do
-			expect{ client_invalid.get_token }.to raise_error
+		it "returns nil" do
+			response = client_invalid.get_token
+			expect(response).to be_nil
 		end
 	end
 

--- a/spec/cassettes/Agendor_Token/invalid_token/returns_nil.yml
+++ b/spec/cassettes/Agendor_Token/invalid_token/returns_nil.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.agendor.com.br/v1/auth/token
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      content-type:
+      - application/json
+      authorization:
+      - Token xunda
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      access-control-allow-headers:
+      - Authorization, Content-Type, If-None-Match, SESSION_ID, VERSION
+      access-control-allow-methods:
+      - GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS
+      access-control-allow-origin:
+      - "*"
+      access-control-expose-headers:
+      - WWW-Authenticate, Server-Authorization
+      access-control-max-age:
+      - '86400'
+      cache-control:
+      - no-cache
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 02 Apr 2018 15:22:51 GMT
+      server:
+      - nginx/1.13.8
+      www-authenticate:
+      - Token error="Bad token"
+      content-length:
+      - '98'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '{"statusCode":401,"error":"Unauthorized","message":"Bad token","attributes":{"error":"Bad
+        token"}}'
+    http_version: '1.1'
+  recorded_at: Mon, 02 Apr 2018 15:22:51 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
When an exception occurs, this gem raises a string error message. Debug strings, is very difficult, and most of the times depends on a parser, to process the string and transform into a more friendly error.

From now, instead of raising a string, we will raise the HTTParty response, which gives us more flexibility to handle the errors.